### PR TITLE
Feat/signal getters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,6 @@ ruff = ">=0.9.10"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.ruff]
+#[tool.ruff]
 # Exclude tests directory from linting
-exclude = ["tests/"]
+#exclude = ["tests/"]

--- a/rkns/handler.py
+++ b/rkns/handler.py
@@ -70,6 +70,9 @@ class StoreHandler:
         rkns_signal = RKNSNodeNames.rkns_signals_group.value
         return cast(zarr.Group, self.rkns[rkns_signal])
 
+    def get_channels_by_fg(self, frequency_group: str) -> list[str]:
+        return cast(list[str], self.signals[frequency_group].attrs["channels"])
+
     def get_group(self, path: str, mode: str = "r") -> zarr.Group:
         """Get a Zarr group at the specified path."""
         return zarr.open_group(self._store, path=path, mode=mode)

--- a/rkns/lazy.py
+++ b/rkns/lazy.py
@@ -7,11 +7,29 @@ T = TypeVar("T", bound=Union[zarr.Array, np.ndarray])
 
 
 class LazySignal:
-    """EDF-format signal specific implementation"""
+    """
+    A lazy-evaluated signal container that applies transformations on-demand.
+
+    This class is designed for signals that are stored similar to EDF (i.e. shifted and scaled) and supports NumPy-like indexing
+    while avoiding premature materialization of the data. It applies scaling and bias
+    transformations only when data is accessed.
+    """
 
     def __init__(
         self, source: zarr.Array | np.ndarray, _m: np.ndarray, _bias: np.ndarray
     ):
+        """
+        Initialize the LazySignal with source data, scaling factors, and biases.
+
+        Parameters
+        ----------
+        source : zarr.Array or np.ndarray
+            The underlying data array to be transformed.
+        _m : np.ndarray
+            Scaling factors of shape (1, n_channels).
+        _bias : np.ndarray
+            Bias terms of shape (1, n_channels).
+        """
         self._source = source
         self._m = _m
         self._bias = _bias
@@ -26,35 +44,73 @@ class LazySignal:
                 f"Shape of scale factor {self._m.shape} does not match source shape {source.shape}."
             )
 
-    """
-    Generic lazy-evaluated container that applies transformations on-demand.
-    Supports all NumPy indexing patterns while avoiding premature materialization.
-
-    Usage:
-    - Inherit and implement `_transform` for specific conversions
-    - Wrap any array-like object (zarr, numpy, etc.)
-    """
-
     def __getitem__(self, idx: Union[int, slice, Tuple, np.ndarray]) -> np.ndarray:
-        """Apply transformation to requested elements.
-        Just forward the slicing logic to source object.
+        """
+        Retrieve transformed data for the given index or slice.
+
+        Parameters
+        ----------
+        idx : int, slice, tuple, or np.ndarray
+            The index or slice to apply to the data.
+
+        Returns
+        -------
+        np.ndarray
+            The transformed data corresponding to the requested slice.
         """
         source_sliced = cast(np.ndarray, self._source.__getitem__(idx))
         return self._transform(source_sliced, idx)
 
     @property
     def shape(self) -> Tuple[int, ...]:
+        """
+        Get the shape of the underlying data.
+
+        Returns
+        -------
+        tuple
+            The shape of the source array.
+        """
         return self._source.shape
 
     @property
     def dtype(self) -> np.dtype:
+        """
+        Get the dtype of the transformed data.
+
+        Returns
+        -------
+        np.dtype
+            The dtype after applying transformations.
+        """
         return np.result_type(self._source.dtype, self._m.dtype)
 
     def __array__(self, dtype: Any = None) -> np.ndarray:
+        """
+        Convert the entire array to a NumPy array.
+
+        Parameters
+        ----------
+        dtype : dtype, optional
+            The desired dtype for the output array.
+
+        Returns
+        -------
+        np.ndarray
+            The fully materialized and transformed array.
+        """
         arr = self[:]  # Materialize full array
         return arr.astype(dtype) if dtype else arr  # type: ignore
 
     def __repr__(self) -> str:
+        """
+        Return a string representation of the LazySignal.
+
+        Returns
+        -------
+        str
+            A string describing the shape and dtype of the signal.
+        """
         return f"{type(self).__name__}(shape={self.shape}, dtype={self.dtype})"
 
     @classmethod
@@ -66,32 +122,54 @@ class LazySignal:
         dmin: np.ndarray,
         dmax: np.ndarray,
     ) -> "LazySignal":
+        """
+        Create a LazySignal from physical and digital min/max values.
+
+        Parameters
+        ----------
+        source : zarr.Array or np.ndarray
+            The source data array.
+        pmin : np.ndarray
+            Physical minimum values.
+        pmax : np.ndarray
+            Physical maximum values.
+        dmin : np.ndarray
+            Digital minimum values.
+        dmax : np.ndarray
+            Digital maximum values.
+
+        Returns
+        -------
+        LazySignal
+            A new LazySignal instance with computed scaling and bias.
+        """
         _m = (pmax - pmin) / (dmax - dmin)
         _bias = (pmax / _m) - dmax
         return cls(source=source, _m=_m, _bias=_bias)
 
     def slice_columns_param(self, idx) -> Tuple[np.ndarray, np.ndarray]:
         """
-        Slice the parameter self._m and self._bias, which are of shape [1, n_channels],
-        as they are intended to be broadcastable to the data.
-        This function should ignore row indexing, and apply channel indexing.
+        Slice the scaling and bias parameters based on indexing.
 
-        Args:
-            idx (_type_): index that is applied to the data, can be any slicing operation passed to __getitem__
+        Handles slicing of parameters to match the data indexing pattern.
 
-        Returns:
-            Tuple[np.ndarray, np.ndarray]: Sliced self._m, self._bias
+        Parameters
+        ----------
+        idx : int, slice, or tuple
+            The index or slice applied to the data.
+
+        Returns
+        -------
+        Tuple[np.ndarray, np.ndarray]
+            The sliced scaling (_m) and bias (_bias) parameters.
         """
         if isinstance(idx, int) or isinstance(idx, slice):
-            # Single integer or single slices, indexes only row, return all params
             return self._m, self._bias
         elif isinstance(idx, tuple):
-            # Handle tuples
             if len(idx) > 2:
                 raise IndexError("Too many indices for 2D array")
             elif len(idx) == 1:
                 return self._m, self._bias
-            # len(idx) == 2
             row, col = idx  # type: ignore
             if row is ...:
                 row = slice(None)
@@ -99,33 +177,52 @@ class LazySignal:
                 col = slice(None)
 
             if isinstance(row, int) and isinstance(col, int):
-                # Single element. data will be a scalar, so _m and _bias should be as well.
                 return self._m[0, col], self._bias[0, col]
             elif isinstance(row, int):
-                # Single row, column slice
                 return self._m[0, col], self._bias[0, col]
             elif isinstance(col, int):
-                # Single column, row slice
                 return self._m[:, col], self._bias[:, col]
             else:
-                # Both row and column slices
                 return self._m[:, col], self._bias[:, col]
         else:
             raise TypeError("Invalid index type")
 
     @staticmethod
     def is_full_slice(s: Union[slice, int, None]) -> bool:
+        """
+        Check if a slice is a full slice ([:]).
+
+        Parameters
+        ----------
+        s : slice, int, or None
+            The slice to check.
+
+        Returns
+        -------
+        bool
+            True if the slice covers the entire range, False otherwise.
+        """
         if isinstance(s, slice):
             return s.start is None and s.stop is None and s.step is None
         return False
 
     def _transform(
-        self, chunk: np.ndarray, idx: Union[int, slice, Tuple, np.ndarray]
+        self, data_slice: np.ndarray, idx: Union[int, slice, Tuple, np.ndarray]
     ) -> np.ndarray:
-        """Apply transformation to requested elements.
-        Handles slicing of _b when the second dimension is sliced (including integer indices).
         """
-        # Extract the second dimension's slice info
+        Apply scaling and bias transformation to the sliced data.
 
+        Parameters
+        ----------
+        chunk : np.ndarray
+            The data chunk to transform.
+        idx : int, slice, tuple, or np.ndarray
+            The index or slice used to retrieve the chunk.
+
+        Returns
+        -------
+        np.ndarray
+            The transformed data chunk.
+        """
         _m, _bias = self.slice_columns_param(idx)
-        return _m * (chunk + _bias)
+        return _m * (data_slice + _bias)

--- a/rkns/lazy.py
+++ b/rkns/lazy.py
@@ -20,11 +20,15 @@ class LazyIndexer(Generic[T]):
         self._source = source
 
     def __getitem__(self, idx: Union[int, slice, Tuple, np.ndarray]) -> np.ndarray:
-        """Apply transformation to requested elements"""
-        source_sliced = cast(np.ndarray, self._source[idx])
-        return self._transform(source_sliced)
+        """Apply transformation to requested elements.
+        Just forward the slicing logic to source object.
+        """
+        source_sliced = cast(np.ndarray, self._source.__getitem__(idx))
+        return self._transform(source_sliced, idx)
 
-    def _transform(self, chunk: np.ndarray) -> np.ndarray:
+    def _transform(
+        self, chunk: np.ndarray, idx: Union[int, slice, Tuple, np.ndarray]
+    ) -> np.ndarray:
         """Override this with domain-specific logic"""
         raise NotImplementedError()
 
@@ -48,11 +52,83 @@ class LazySignal(LazyIndexer[zarr.Array]):
     """EDF-format signal specific implementation"""
 
     def __init__(
-        self, source: zarr.Array, pmin: float, pmax: float, dmin: float, dmax: float
+        self,
+        source: zarr.Array,
+        pmin: np.ndarray,
+        pmax: np.ndarray,
+        dmin: np.ndarray,
+        dmax: np.ndarray,
     ):
         super().__init__(source)
         self._m = (pmax - pmin) / (dmax - dmin)
         self._bias = (pmax / self._m) - dmax
 
-    def _transform(self, chunk: np.ndarray) -> np.ndarray:
-        return self._m * (chunk + self._bias)
+        if len(self._m.shape) != 2 or self._m.shape[1] != source.shape[1]:
+            raise ValueError(
+                f"Shape of scale factor {self._m.shape} does not match source shape {source.shape}."
+            )
+
+        if len(self._bias.shape) != 2 or self._bias.shape[1] != source.shape[1]:
+            raise ValueError(
+                f"Shape of scale factor {self._m.shape} does not match source shape {source.shape}."
+            )
+
+    def slice_transform_param(self, idx) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Slice the parameter self._m and self._bias, which are of shape [1, n_channels],
+        as they are intended to be broadcastable to the data.
+        This function should ignore row indexing, and apply channel indexing.
+
+        Args:
+            idx (_type_): index that is applied to the data, can be any slicing operation passed to __getitem__
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Sliced self._m, self._bias
+        """
+        if isinstance(idx, int) or isinstance(idx, slice):
+            # Single integer or single slices, indexes only row, return all params
+            return self._m, self._bias
+        elif isinstance(idx, tuple):
+            # Handle tuples
+            if len(idx) > 2:
+                raise IndexError("Too many indices for 2D array")
+            elif len(idx) == 1:
+                return self._m, self._bias
+            # len(idx) == 2
+            row, col = idx  # type: ignore
+            if row is ...:
+                row = slice(None)
+            if col is ...:
+                col = slice(None)
+
+            if isinstance(row, int) and isinstance(col, int):
+                # Single element. data will be a scalar, so _m and _bias should be as well.
+                return self._m[0, col], self._bias[0, col]
+            elif isinstance(row, int):
+                # Single row, column slice
+                return self._m[0, col], self._bias[0, col]
+            elif isinstance(col, int):
+                # Single column, row slice
+                return self._m[:, col], self._bias[:, col]
+            else:
+                # Both row and column slices
+                return self._m[:, col], self._bias[:, col]
+        else:
+            raise TypeError("Invalid index type")
+
+    @staticmethod
+    def is_full_slice(s: Union[slice, int, None]) -> bool:
+        if isinstance(s, slice):
+            return s.start is None and s.stop is None and s.step is None
+        return False
+
+    def _transform(
+        self, chunk: np.ndarray, idx: Union[int, slice, Tuple, np.ndarray]
+    ) -> np.ndarray:
+        """Apply transformation to requested elements.
+        Handles slicing of _b when the second dimension is sliced (including integer indices).
+        """
+        # Extract the second dimension's slice info
+
+        _m, _bias = self.slice_transform_param(idx)
+        return _m * (chunk + _bias)

--- a/rkns/lazy.py
+++ b/rkns/lazy.py
@@ -1,0 +1,58 @@
+from typing import Any, Generic, Tuple, TypeVar, Union, cast
+
+import numpy as np
+import zarr
+
+T = TypeVar("T", bound=Union[zarr.Array, np.ndarray])
+
+
+class LazyIndexer(Generic[T]):
+    """
+    Generic lazy-evaluated container that applies transformations on-demand.
+    Supports all NumPy indexing patterns while avoiding premature materialization.
+
+    Usage:
+    - Inherit and implement `_transform` for specific conversions
+    - Wrap any array-like object (zarr, numpy, etc.)
+    """
+
+    def __init__(self, source: T):
+        self._source = source
+
+    def __getitem__(self, idx: Union[int, slice, Tuple, np.ndarray]) -> np.ndarray:
+        """Apply transformation to requested elements"""
+        source_sliced = cast(np.ndarray, self._source[idx])
+        return self._transform(source_sliced)
+
+    def _transform(self, chunk: np.ndarray) -> np.ndarray:
+        """Override this with domain-specific logic"""
+        raise NotImplementedError()
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self._source.shape
+
+    @property
+    def dtype(self) -> np.dtype:
+        return np.result_type(self._source.dtype, np.float32)
+
+    def __array__(self, dtype: Any = None) -> np.ndarray:
+        arr = self[:]  # Materialize full array
+        return arr.astype(dtype) if dtype else arr
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(shape={self.shape}, dtype={self.dtype})"
+
+
+class LazySignal(LazyIndexer[zarr.Array]):
+    """EDF-format signal specific implementation"""
+
+    def __init__(
+        self, source: zarr.Array, pmin: float, pmax: float, dmin: float, dmax: float
+    ):
+        super().__init__(source)
+        self._m = (pmax - pmin) / (dmax - dmin)
+        self._bias = (pmax / self._m) - dmax
+
+    def _transform(self, chunk: np.ndarray) -> np.ndarray:
+        return self._m * (chunk + self._bias)

--- a/rkns/rkns.py
+++ b/rkns/rkns.py
@@ -87,6 +87,28 @@ class RKNS:
         sfreq_Hz: float | None = None,
         time_range: tuple[float, float] = (0, np.inf),
     ) -> np.ndarray:
+        """Get signal data for specified channels or frequency group.
+
+        Parameters
+        ----------
+        channels
+            Channel name(s) to retrieve. Mutually exclusive with `sfreq_Hz`.
+        sfreq_Hz
+            Sampling frequency in Hz to retrieve. Mutually exclusive with `channels`.
+        time_range : tuple[float, float], optional
+            Time range in seconds to retrieve, by default (0, inf), i.e. the whole time frame.
+            The time is with respect to the record duration.
+
+        Returns
+        -------
+            Signal data array for the specified parameters.
+
+        Raises
+        ------
+        ValueError
+            If both channels and frequency are specified, or neither is specified.
+            If specified channels belong to different frequency groups.
+        """
         if channels is not None and sfreq_Hz is not None:
             raise ValueError("Specify either channels or frequency, not both.")
         elif channels is None and sfreq_Hz is None:
@@ -121,6 +143,26 @@ class RKNS:
         sfreq_Hz: float,
         time_range: tuple[float, float] = (0, np.inf),
     ):
+        """
+        Build a row index slice from a given time range for samples with the given sampling frequency.
+
+        Parameters
+        ----------
+        sfreq_Hz : float
+            Sampling frequency in Hz.
+        time_range : tuple[float, float]
+            Time range in seconds (start, end). If `None`, defaults to (0, inf).
+
+        Returns
+        -------
+        slice
+            Slice object representing the row indices corresponding to the time range.
+
+        Raises
+        ------
+        ValueError
+            If the end time is not larger than the start time.
+        """
         if time_range[0] is None:
             time_range[0] = 0
 
@@ -141,6 +183,21 @@ class RKNS:
     def __build_col_idx_from_channels(
         self, channels: Iterable[str] | None, frequency_group: str
     ) -> list[int] | EllipsisType:
+        """
+        Convert channel names to their corresponding column indices for a given frequency group.
+
+        Parameters
+        ----------
+        channels
+            List of channel names to convert to indices. If None, returns `...` (Ellipsis)
+            to indicate all channels should be selected.
+        frequency_group
+            The frequency group to which the channels belong.
+
+        Returns
+        -------
+            List of column indices corresponding to the given channels, or `...` if no channels are specified.
+        """
         if channels is None:
             return ...
         channel_to_index = self.get_channel_order(frequency_group=frequency_group)

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+import zarr
+
+from rkns.lazy import LazyIndexer, LazySignal
+
+
+class TestLazyIndexer:
+    def test_abstract_base_raises(self):
+        """Test base class requires implementation"""
+        with pytest.raises(NotImplementedError):
+
+            class ConcreteIndexer(LazyIndexer):
+                pass  # Missing _transform
+
+            ConcreteIndexer(np.array([1, 2, 3]))[0]
+
+    def test_shape_proxy(self):
+        """Test shape property delegates to source"""
+        source = zarr.array(np.random.rand(10, 20))
+
+        class DummyIndexer(LazyIndexer):
+            def _transform(self, chunk):
+                return chunk * 2
+
+        lazy = DummyIndexer(source)
+        assert lazy.shape == (10, 20)
+
+
+class TestLazySignal:
+    @pytest.fixture
+    def test_signal(self):
+        """Create test signal with known scaling"""
+        digital = zarr.array([1000, 2000, 3000], dtype="int16")
+        return LazySignal(digital, pmin=-1.0, pmax=1.0, dmin=0, dmax=3000)
+
+    def test_scaling_calculation(self, test_signal):
+        """Verify EDF scaling formula"""
+        assert pytest.approx(test_signal._m) == 2 / 3000
+        assert pytest.approx(test_signal._bias) == -1500
+
+    def test_value_transform(self, test_signal):
+        """Test physical value conversion"""
+        # Known test case:
+        # physical = (2/3000) * (digital - 1500)
+        assert pytest.approx(test_signal[0]) == -0.3333333
+        assert pytest.approx(test_signal[2]) == 1.0
+
+    def test_array_interface(self, test_signal):
+        """Test NumPy compatibility"""
+        arr = np.array(test_signal)
+        assert arr.shape == (3,)
+        assert arr.dtype == np.float64
+        assert pytest.approx(arr[0]) == -0.333333  # Midpoint should be zero
+
+    def test_slicing(self, test_signal):
+        """Test partial materialization"""
+        chunk = test_signal[1:3]
+        assert len(chunk) == 2
+        assert pytest.approx(chunk[1]) == 1.0

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -58,3 +58,15 @@ class TestLazySignal:
         chunk = test_signal[1:3]
         assert len(chunk) == 2
         assert pytest.approx(chunk[1]) == 1.0
+
+    def test_multiindex_slicing(self, test_signal):
+        """Test partial materialization"""
+
+        digital = zarr.array(np.arange(250).reshape(10, 25), dtype="int16")
+        signal = LazySignal(digital, pmin=-1.0, pmax=1.0, dmin=0, dmax=3000)
+
+        assert np.isscalar(signal[0, 0])
+        assert signal[:10, :10].shape == (10, 10)
+        assert signal[:10, :].shape == (10, digital.shape[1])
+
+        # assert pytest.approx(chunk[1]) == 1.0

--- a/tests/test_raw_from_file.py
+++ b/tests/test_raw_from_file.py
@@ -1,10 +1,8 @@
 import hashlib
-import os
 import tempfile
 from pathlib import Path
 
 import pytest
-import zarr
 
 from rkns.rkns import RKNS
 from rkns.util import RKNSNodeNames

--- a/tests/test_rkns_from_file.py
+++ b/tests/test_rkns_from_file.py
@@ -113,11 +113,11 @@ def test_frequency_by_channel(path, rkns_obj, pyedf_digital):
 @pytest.mark.parametrize("path", paths)
 def test_rkns_from_edf_attributes(path, rkns_obj, pyedf_digital):
     channel_data_dig, signal_headers, header = pyedf_digital
-    reference_fgs = {
+    {
         s["label"]: get_freq_group(s["sample_frequency"]) for s in signal_headers
     }
 
-    fg_names = rkns_obj._get_frequencygroups()
+    rkns_obj._get_frequencygroups()
     with pyedflib.EdfReader(path) as pyedf:
         assert pyedf.getBirthdate() == rkns_obj.patient_info["birthdate"]  # type: ignore
         assert pyedf.getSex() == rkns_obj.patient_info["sex"]  # type: ignore

--- a/tests/test_rkns_from_file.py
+++ b/tests/test_rkns_from_file.py
@@ -1,15 +1,13 @@
 import hashlib
-import os
 import tempfile
 from pathlib import Path
 
 import numpy as np
 import pyedflib
 import pytest
-import zarr
 
 from rkns.rkns import RKNS
-from rkns.util import check_validity, deep_compare_groups
+from rkns.util import check_validity
 from rkns.util.rkns_util import check_raw_validity, check_rkns_validity
 
 paths = ["tests/files/test_file.edf"]
@@ -185,10 +183,15 @@ def test_rkns_from_edf_physical(path, rkns_obj, pyedf_physical):
     for fg in fgs:
         channel_names = rkns_obj._get_channel_names_by_fg(fg)
         rkns_physical_signal = rkns_obj._get_signal_by_fg(fg)
+        rkns_physical_signal_direct = rkns_obj._get_signal_by_freq(float(fg[3:]))
+
         for i, channel_name in enumerate(channel_names):
             val1 = reference_fgs[channel_name]
             val2 = rkns_physical_signal[:].T[i]
+            val3 = rkns_physical_signal_direct[:].T[i]
+
             np.testing.assert_allclose(val1, val2)
+            np.testing.assert_allclose(val2, val3)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,6 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-import numpy as np
 import pytest
-import zarr
-import zarr.codecs
-from rich.tree import Tree
 
 from rkns.util.misc import (
     TreeRepr,

--- a/tests/test_zarr_util.py
+++ b/tests/test_zarr_util.py
@@ -398,8 +398,8 @@ def test_deep_compare_async_groups_path_mismatch():
 def test_deep_compare_async_groups_array_shape_mismatch():
     mock_group1 = generate_group()
     mock_group2 = generate_group()
-    arr1 = mock_group1.create_array("array1", dtype=np.float32, shape=(3,))
-    arr2 = mock_group2.create_array("array1", dtype=np.float32, shape=(4,))
+    mock_group1.create_array("array1", dtype=np.float32, shape=(3,))
+    mock_group2.create_array("array1", dtype=np.float32, shape=(4,))
 
     with pytest.raises(ArrayShapeMismatchError):
         deep_compare_groups(mock_group1, mock_group2)
@@ -435,10 +435,10 @@ def test_deep_compare_async_groups_root_name_mismatch():
     mock_group1 = generate_group("a")
     mock_group2 = generate_group("a")
     sg1 = mock_group1.create_group("subgroup1")
-    ssg1 = sg1.create_group("grandchild")
+    sg1.create_group("grandchild")
 
     sg2 = mock_group2.create_group("subgroup2")
-    ssg2 = sg2.create_group("grandchild")
+    sg2.create_group("grandchild")
     with pytest.raises(PathMismatchError):
         deep_compare_groups(mock_group1, mock_group2)
 
@@ -447,10 +447,10 @@ def test_deep_compare_async_groups_same_tree():
     mock_group1 = generate_group("a")
     mock_group2 = generate_group("a")
     sg1 = mock_group1.create_group("subgroup1")
-    ssg1 = sg1.create_group("grandchild")
+    sg1.create_group("grandchild")
 
     sg2 = mock_group2.create_group("subgroup1")
-    ssg2 = sg2.create_group("grandchild")
+    sg2.create_group("grandchild")
     deep_compare_groups(mock_group1, mock_group2)
 
 
@@ -472,8 +472,8 @@ def test_deep_compare_async_groups_attribute_mismatch():
 def test_deep_compare_async_groups_array_and_group():
     mock_group1 = generate_group()
     mock_group2 = generate_group()
-    arr1 = mock_group1.create_group("abca")
-    arr2 = mock_group2.create_array("array1", dtype=np.float32, shape=(4,))
+    mock_group1.create_group("abca")
+    mock_group2.create_array("array1", dtype=np.float32, shape=(4,))
 
     with pytest.raises(GroupComparisonError):
         deep_compare_groups(mock_group1, mock_group2)

--- a/tests/test_zarr_util.py
+++ b/tests/test_zarr_util.py
@@ -1,12 +1,9 @@
-from typing import Iterable
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
 import zarr
 import zarr.codecs
 import zarr.storage
-from zarr import AsyncGroup
 from zarr.codecs.blosc import BloscCname, BloscCodec, BloscShuffle
 from zarr.storage import LocalStore, MemoryStore
 
@@ -15,7 +12,6 @@ from rkns.util.zarr_util import (
     ArrayValueMismatchError,
     AttributeMismatchError,
     GroupComparisonError,
-    GroupPathMismatchError,
     MemberCountMismatchError,
     NameMismatchError,
     PathMismatchError,


### PR DESCRIPTION
# Pull Request

## Description
Added support for the most important getters along the time and channel/frequency group axes.
This also came with a lazy evaluation for the signals, as the digital signals have to be transformed on the fly.

### What changes have you made?
- Added LazySignal, a class that acts like a numpy array and supports lazy loading of an array with subsequent transformations (here shift and scale).
- Added get_signal with a general interface that allows slicing in both time, channel, and frequency dimension.
  This only supports individual frequency groups, as multiple groups would break the signature of the return value.
  The most important part here, is that all slices are applied at once, so that zarrs efficient chunk based indexing can be used.

### Why did you make these changes?
These getters are the main interface for users.

### Additional Information
The LazySignal does not yet support a setter.

## Checklist
<!-- Ensure the following tasks are completed before submitting the PR: -->
- [x] Updated the documentation with any interface changes.
- [x] Verified all tests pass and added new tests for new functionality.
- [x] Updated version numbers if applicable.
- [x] Ensured the code follows the project's coding standards (e.g., ran linters).
